### PR TITLE
(fix) correct evaluation of bnbPrice check

### DIFF
--- a/src/pages/Treasury/Treasury.js
+++ b/src/pages/Treasury/Treasury.js
@@ -27,7 +27,7 @@ export const Treasury = () => {
       );
 
       let bnbPrice = res.data.data['BNB']?.quote.USD.price;
-      if (bnbPrice !== undefined) {
+      if (typeof bnbPrice !== 'undefined') {
         let bnbValuable = ethers.utils.formatUnits(bnbBalance, 18) * bnbPrice;
         setBNBBalance('$' + bnbValuable.toFixed(1));
       } else {

--- a/src/pages/Treasury/Treasury.js
+++ b/src/pages/Treasury/Treasury.js
@@ -27,7 +27,7 @@ export const Treasury = () => {
       );
 
       let bnbPrice = res.data.data['BNB']?.quote.USD.price;
-      if (typeof bnbPrice !== undefined) {
+      if (bnbPrice !== undefined) {
         let bnbValuable = ethers.utils.formatUnits(bnbBalance, 18) * bnbPrice;
         setBNBBalance('$' + bnbValuable.toFixed(1));
       } else {


### PR DESCRIPTION
`if (typeof bnbPrice !== undefined)` will always evaluate to true, because `typeof` returns a string, not an object. 

To properly compare values, we instead do `if (typeof bnbPrice !== 'undefined')`, as this properly checks if the object types are matched, by comparing the string representation of the object types. This still avoids a ReferenceError if bnbPrice hasn't been initialized.
